### PR TITLE
Current Vesc integration for app compatibility 

### DIFF
--- a/.github/workflows/generate_bin.yml
+++ b/.github/workflows/generate_bin.yml
@@ -42,7 +42,7 @@ jobs:
         architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
     - run: python tools/xiaotea/Scripts/prepareZip_online.py      
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: ${{ github.workspace }}/tools/zip_output
         name: M365_v3_build1_${{ github.run_number }}

--- a/.github/workflows/generate_bin.yml
+++ b/.github/workflows/generate_bin.yml
@@ -45,5 +45,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         path: ${{ github.workspace }}/tools/zip_output
-        name: M365_v3_build_${{ github.run_number }}
+        name: M365_v3_build1_${{ github.run_number }}
         retention-days: 5

--- a/Core/Inc/config.h
+++ b/Core/Inc/config.h
@@ -4,7 +4,7 @@
 #define BRAKEMAX 100
 
 // speed limits for invividual modes in kph
-#define SPEEDLIMIT_ECO 6
+#define SPEEDLIMIT_ECO 12
 #define SPEEDLIMIT_NORMAL 20
 #define SPEEDLIMIT_SPORT 50
 


### PR DESCRIPTION
Hopefully the changes made here are able to be tested by someone soon as I'm currently not near proper equipment however this should make it possible to interface the m365 esc if running this firmware with the VESC app using usart3 hopefully someone can check it out and let me know if it maths